### PR TITLE
feat: Add minimal source files to create repo structure and cargo workspace

### DIFF
--- a/rust-keybroker/Cargo.toml
+++ b/rust-keybroker/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+
+members = [
+    "keybroker-client",
+    "keybroker-common",
+    "keybroker-server",
+    "keybroker-app",
+]

--- a/rust-keybroker/keybroker-app/Cargo.toml
+++ b/rust-keybroker/keybroker-app/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "keybroker-app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+keybroker-client = { path = "../keybroker-client" }

--- a/rust-keybroker/keybroker-app/src/main.rs
+++ b/rust-keybroker/keybroker-app/src/main.rs
@@ -1,0 +1,6 @@
+// Copyright 2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/rust-keybroker/keybroker-client/Cargo.toml
+++ b/rust-keybroker/keybroker-client/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "keybroker-client"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+keybroker-common = { path = "../keybroker-common" }

--- a/rust-keybroker/keybroker-client/src/lib.rs
+++ b/rust-keybroker/keybroker-client/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright 2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/rust-keybroker/keybroker-common/Cargo.toml
+++ b/rust-keybroker/keybroker-common/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "keybroker-common"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust-keybroker/keybroker-common/src/lib.rs
+++ b/rust-keybroker/keybroker-common/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright 2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/rust-keybroker/keybroker-server/Cargo.toml
+++ b/rust-keybroker/keybroker-server/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "keybroker-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+keybroker-common = { path = "../keybroker-common" }

--- a/rust-keybroker/keybroker-server/src/main.rs
+++ b/rust-keybroker/keybroker-server/src/main.rs
@@ -1,0 +1,6 @@
+// Copyright 2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
feat: Add minimal source files to create repo structure and cargo workspace

No actual functional code yet - just the Cargo defaults, but with Veraison copyright and licence headers added.

Structure is four crates:

- keybroker-server (bin) is the service
- keybroker-client (lib) is the client library
- keybroker-app (bin) is a simple client application, which will consume the client library and get a secret from the service to display on the console
- keybroker-common (lib) any common data types used by both the service and the client (eg. type-safe models of the objects in the API)