### PR TITLE
First functional chunk of server code

### DIFF
--- a/rust-keybroker/keybroker-app/Cargo.toml
+++ b/rust-keybroker/keybroker-app/Cargo.toml
@@ -2,6 +2,13 @@
 name = "keybroker-app"
 version = "0.1.0"
 edition = "2021"
+authors = ["Veraison Project Contributors"]
+description = "Simple command-line application demonstrating the keybroker."
+license = "Apache-2.0"
+repository = "https://github.com/veraison/keybroker-demo"
+readme = "README.md"
+keywords = ["security", "service", "attestation"]
+categories = ["cryptography", "hardware-support"]
 
 [dependencies]
 keybroker-client = { path = "../keybroker-client" }

--- a/rust-keybroker/keybroker-client/Cargo.toml
+++ b/rust-keybroker/keybroker-client/Cargo.toml
@@ -2,6 +2,13 @@
 name = "keybroker-client"
 version = "0.1.0"
 edition = "2021"
+authors = ["Veraison Project Contributors"]
+description = "Rust client library for the demo keybroker."
+license = "Apache-2.0"
+repository = "https://github.com/veraison/keybroker-demo"
+readme = "README.md"
+keywords = ["security", "service", "attestation"]
+categories = ["cryptography", "hardware-support"]
 
 [dependencies]
 keybroker-common = { path = "../keybroker-common" }

--- a/rust-keybroker/keybroker-common/Cargo.toml
+++ b/rust-keybroker/keybroker-common/Cargo.toml
@@ -2,6 +2,13 @@
 name = "keybroker-common"
 version = "0.1.0"
 edition = "2021"
+authors = ["Veraison Project Contributors"]
+description = "Common API data types used by both server and client for the demo keybroker."
+license = "Apache-2.0"
+repository = "https://github.com/veraison/keybroker-demo"
+readme = "README.md"
+keywords = ["security", "service", "attestation"]
+categories = ["cryptography", "hardware-support"]
 
 [dependencies]
 serde = { version = "1.0.204", features = ["serde_derive"] }

--- a/rust-keybroker/keybroker-common/Cargo.toml
+++ b/rust-keybroker/keybroker-common/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+serde = { version = "1.0.204", features = ["serde_derive"] }
+serde_with = "3.9.0"

--- a/rust-keybroker/keybroker-common/src/lib.rs
+++ b/rust-keybroker/keybroker-common/src/lib.rs
@@ -1,29 +1,55 @@
 // Copyright 2024 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
+//! This library provides the common data types that are defined in the OpenAPI schema for the keybroker,
+//! along with the serialization functionality that allows them to be transacted over HTTP. The small collection
+//! of data types in this library are consumed by both the server and the client.
+
+/// Represents a single attestation challenge (nonce).
+///
+/// Challenges are formed in response to a key access request. The purpose of the key broker is to provide
+/// keys (secret strings) in exchange for a verifiable attestation token. In order to produce an attestation
+/// token, the client must first be given the challenge value (commonly called a "nonce"). This structure
+/// provides the nonce along with a vector of permissible evidence content types that the server will
+/// accept.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
-
 pub struct AttestationChallenge {
+    /// Base64 encoding of the challenge value (nonce). The client must incorporate this challenge value
+    /// into its attestation token/evidence, according to the conventions of the evidence bundle being
+    /// formed.
     pub challenge: String,
+
+    /// List of acceptable evidence media types, such as "application/eat-collection; profile=http://arm.com/CCA-SSD/1.0.0".
     pub accept: Vec<EvidenceContentType>,
 }
 
+/// A request to access a key or secret string according to the "background check" interaction pattern
+/// for attestation.
+///
+/// The identity of the key being accessed is not part of this structure, because it is implicit in the path
+/// of the API request to access a key.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
-
 pub struct BackgroundCheckKeyRequest {
+    /// The public part of the wrapping key pair that the client has specified for encryption of the key/secret
+    /// in transit. The keybroker server uses this public key to wrap (encrypt) the data before returning
+    /// it to the client. This is in order for confidentiality to be maintained without relying solely on TLS
+    /// between the client and the server.
     pub pubkey: PublicWrappingKey,
 }
 
+/// Represents an error occurring within the API usage.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
-
 pub struct ErrorInformation {
+    /// Formal type string for the error.
     pub r#type: String,
+
+    /// Human-readable error details, giving more information about the error.
     pub detail: String,
 }
 
@@ -31,21 +57,39 @@ pub type EvidenceBytes = String;
 
 pub type EvidenceContentType = String;
 
+/// The public portion of a wrapping key pair used to protect keys/secrets in transit between the client and
+/// the server.
+///
+/// Wrapping keys are used so that confidentiality of the brokered data is maintained without relying solely
+/// on TLS between the client and the server.
+///
+/// Only the client (within its confidential compute environment) has the private part of the key pair, with
+/// which it can decrypt and use the data from the server.
+///
+/// Only RSA keys are currently supported for wrapping.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
-
 pub struct PublicWrappingKey {
+    /// Public key type. This must be "RSA".
     pub kty: String,
+
+    /// Encryption algorithm. This must be either "RSA1_5" or "OAEP".
     pub alg: String,
+
+    /// Base64 encoding of the public key modulus.
     pub n: String,
+
+    /// Base64 encoding of the public key exponent.
     pub e: String,
 }
 
+/// Wrapped/encrypted secret data returned from the server in the case of a successfully-verified attestation.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
-
 pub struct WrappedKeyData {
+    /// Base64 encoding of encrypted data. The client should Base64-decode this string, and then RSA decrypt the
+    /// resulting vector of bytes in order to obtain the secret data payload.
     pub data: String,
 }

--- a/rust-keybroker/keybroker-common/src/lib.rs
+++ b/rust-keybroker/keybroker-common/src/lib.rs
@@ -1,17 +1,51 @@
 // Copyright 2024 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+
+pub struct AttestationChallenge {
+    pub challenge: String,
+    pub accept: Vec<EvidenceContentType>,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
+pub struct BackgroundCheckKeyRequest {
+    pub pubkey: PublicWrappingKey,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+
+pub struct ErrorInformation {
+    pub r#type: String,
+    pub detail: String,
+}
+
+pub type EvidenceBytes = String;
+
+pub type EvidenceContentType = String;
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+
+pub struct PublicWrappingKey {
+    pub kty: String,
+    pub alg: String,
+    pub n: String,
+    pub e: String,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+
+pub struct WrappedKeyData {
+    pub data: String,
 }

--- a/rust-keybroker/keybroker-server/Cargo.toml
+++ b/rust-keybroker/keybroker-server/Cargo.toml
@@ -4,4 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+actix-web = "4"
+base64 = "0.22.1"
+thiserror = "1.0.63"
+serde = "1.0.204"
 keybroker-common = { path = "../keybroker-common" }
+veraison-apiclient = { git = "https://github.com/veraison/rust-apiclient.git" }
+ear = { git = "https://github.com/veraison/rust-ear.git" }

--- a/rust-keybroker/keybroker-server/Cargo.toml
+++ b/rust-keybroker/keybroker-server/Cargo.toml
@@ -8,6 +8,8 @@ actix-web = "4"
 base64 = "0.22.1"
 thiserror = "1.0.63"
 serde = "1.0.204"
+rsa = "0.9.6"
+rand = "0.8.5"
 keybroker-common = { path = "../keybroker-common" }
 veraison-apiclient = { git = "https://github.com/veraison/rust-apiclient.git" }
 ear = { git = "https://github.com/veraison/rust-ear.git" }

--- a/rust-keybroker/keybroker-server/Cargo.toml
+++ b/rust-keybroker/keybroker-server/Cargo.toml
@@ -2,6 +2,13 @@
 name = "keybroker-server"
 version = "0.1.0"
 edition = "2021"
+authors = ["Veraison Project Contributors"]
+description = "A simple web service that can provide keys and secrets in exchange for verifiable attestation tokens."
+license = "Apache-2.0"
+repository = "https://github.com/veraison/keybroker-demo"
+readme = "README.md"
+keywords = ["security", "service", "attestation"]
+categories = ["cryptography", "hardware-support"]
 
 [dependencies]
 actix-web = "4"

--- a/rust-keybroker/keybroker-server/Cargo.toml
+++ b/rust-keybroker/keybroker-server/Cargo.toml
@@ -11,6 +11,7 @@ serde = "1.0.204"
 rsa = "0.9.6"
 sha2 = "0.10.8"
 rand = "0.8.5"
+clap = { version = "=4.3.24", features = ["derive", "std"] }
 keybroker-common = { path = "../keybroker-common" }
 veraison-apiclient = { git = "https://github.com/veraison/rust-apiclient.git" }
 ear = { git = "https://github.com/veraison/rust-ear.git" }

--- a/rust-keybroker/keybroker-server/Cargo.toml
+++ b/rust-keybroker/keybroker-server/Cargo.toml
@@ -9,6 +9,7 @@ base64 = "0.22.1"
 thiserror = "1.0.63"
 serde = "1.0.204"
 rsa = "0.9.6"
+sha2 = "0.10.8"
 rand = "0.8.5"
 keybroker-common = { path = "../keybroker-common" }
 veraison-apiclient = { git = "https://github.com/veraison/rust-apiclient.git" }

--- a/rust-keybroker/keybroker-server/src/challenge.rs
+++ b/rust-keybroker/keybroker-server/src/challenge.rs
@@ -1,0 +1,84 @@
+// Copyright 2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::Result;
+use keybroker_common::PublicWrappingKey;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct Challenge {
+    pub challenge_id: u32,
+    pub key_id: String,
+    pub wrapping_key: PublicWrappingKey,
+    pub challenge_value: Vec<u8>,
+}
+
+pub struct Challenger {
+    challenge_table: HashMap<u32, Challenge>,
+}
+
+// This is the challenge value from from https://git.trustedfirmware.org/TF-M/tf-m-tools/+/refs/heads/main/iat-verifier/tests/data/cca_example_token.cbor
+// TODO: This is only being used during early development of the service, where the client is being mocked and therefore certain fixed values are
+// expected. As soon as we move to proper random nonces and testing with real clients, this constant should be deleted.
+const CCA_EXAMPLE_TOKEN_NONCE: &'static [u8] = &[
+    0x6e, 0x86, 0xd6, 0xd9, 0x7c, 0xc7, 0x13, 0xbc, 0x6d, 0xd4, 0x3d, 0xbc, 0xe4, 0x91, 0xa6, 0xb4,
+    0x03, 0x11, 0xc0, 0x27, 0xa8, 0xbf, 0x85, 0xa3, 0x9d, 0xa6, 0x3e, 0x9c, 0xe4, 0x4c, 0x13, 0x2a,
+    0x8a, 0x11, 0x9d, 0x29, 0x6f, 0xae, 0x6a, 0x69, 0x99, 0xe9, 0xbf, 0x3e, 0x44, 0x71, 0xb0, 0xce,
+    0x01, 0x24, 0x5d, 0x88, 0x94, 0x24, 0xc3, 0x1e, 0x89, 0x79, 0x3b, 0x3b, 0x1d, 0x6b, 0x15, 0x04,
+];
+
+impl Challenger {
+    pub fn new() -> Challenger {
+        Challenger {
+            challenge_table: HashMap::new(),
+        }
+    }
+
+    pub fn create_challenge(
+        &mut self,
+        key_id: &String,
+        wrapping_key: &PublicWrappingKey,
+    ) -> Challenge {
+        // All challenges are given random u32 identities
+        let mut challenge_id: u32 = rand::random();
+
+        // Simple lightweight collision avoidance - probably not needed given u32 distribution space,
+        // but it's easy to do. Also allows us to throw out zero if we get it.
+        while challenge_id == 0 || self.challenge_table.contains_key(&challenge_id) {
+            challenge_id = rand::random();
+        }
+
+        let challenge = Challenge {
+            challenge_id: challenge_id,
+            key_id: key_id.clone(),
+            wrapping_key: wrapping_key.clone(),
+            // TODO: We should create a random nonce here. The use of this mock value allows the
+            // server to be tested with a hard-coded example attestation token during development.
+            challenge_value: CCA_EXAMPLE_TOKEN_NONCE.to_vec(),
+        };
+
+        self.challenge_table.insert(challenge_id, challenge.clone());
+
+        challenge
+    }
+
+    pub fn get_challenge(&self, challenge_id: u32) -> Result<Challenge> {
+        let challenge = self.challenge_table.get(&challenge_id);
+        match challenge {
+            Some(c) => Ok(c.clone()),
+            None => Err(crate::error::Error::ChallengeError(
+                crate::error::ChallengeErrorKind::ChallengeNotFound,
+            )),
+        }
+    }
+
+    pub fn delete_challenge(&mut self, challenge_id: u32) -> Result<()> {
+        let challenge = self.challenge_table.remove(&challenge_id);
+        match challenge {
+            Some(c) => Ok(()),
+            None => Err(crate::error::Error::ChallengeError(
+                crate::error::ChallengeErrorKind::ChallengeNotFound,
+            )),
+        }
+    }
+}

--- a/rust-keybroker/keybroker-server/src/challenge.rs
+++ b/rust-keybroker/keybroker-server/src/challenge.rs
@@ -75,7 +75,7 @@ impl Challenger {
     pub fn delete_challenge(&mut self, challenge_id: u32) -> Result<()> {
         let challenge = self.challenge_table.remove(&challenge_id);
         match challenge {
-            Some(c) => Ok(()),
+            Some(_c) => Ok(()),
             None => Err(crate::error::Error::ChallengeError(
                 crate::error::ChallengeErrorKind::ChallengeNotFound,
             )),

--- a/rust-keybroker/keybroker-server/src/challenge.rs
+++ b/rust-keybroker/keybroker-server/src/challenge.rs
@@ -20,7 +20,7 @@ pub struct Challenger {
 // This is the challenge value from from https://git.trustedfirmware.org/TF-M/tf-m-tools/+/refs/heads/main/iat-verifier/tests/data/cca_example_token.cbor
 // TODO: This is only being used during early development of the service, where the client is being mocked and therefore certain fixed values are
 // expected. As soon as we move to proper random nonces and testing with real clients, this constant should be deleted.
-const CCA_EXAMPLE_TOKEN_NONCE: &'static [u8] = &[
+const CCA_EXAMPLE_TOKEN_NONCE: &[u8] = &[
     0x6e, 0x86, 0xd6, 0xd9, 0x7c, 0xc7, 0x13, 0xbc, 0x6d, 0xd4, 0x3d, 0xbc, 0xe4, 0x91, 0xa6, 0xb4,
     0x03, 0x11, 0xc0, 0x27, 0xa8, 0xbf, 0x85, 0xa3, 0x9d, 0xa6, 0x3e, 0x9c, 0xe4, 0x4c, 0x13, 0x2a,
     0x8a, 0x11, 0x9d, 0x29, 0x6f, 0xae, 0x6a, 0x69, 0x99, 0xe9, 0xbf, 0x3e, 0x44, 0x71, 0xb0, 0xce,
@@ -36,7 +36,7 @@ impl Challenger {
 
     pub fn create_challenge(
         &mut self,
-        key_id: &String,
+        key_id: &str,
         wrapping_key: &PublicWrappingKey,
     ) -> Challenge {
         // All challenges are given random u32 identities
@@ -49,8 +49,8 @@ impl Challenger {
         }
 
         let challenge = Challenge {
-            challenge_id: challenge_id,
-            key_id: key_id.clone(),
+            challenge_id,
+            key_id: key_id.to_owned(),
             wrapping_key: wrapping_key.clone(),
             // TODO: We should create a random nonce here. The use of this mock value allows the
             // server to be tested with a hard-coded example attestation token during development.
@@ -66,7 +66,7 @@ impl Challenger {
         let challenge = self.challenge_table.get(&challenge_id);
         match challenge {
             Some(c) => Ok(c.clone()),
-            None => Err(crate::error::Error::ChallengeError(
+            None => Err(crate::error::Error::Challenge(
                 crate::error::ChallengeErrorKind::ChallengeNotFound,
             )),
         }
@@ -76,7 +76,7 @@ impl Challenger {
         let challenge = self.challenge_table.remove(&challenge_id);
         match challenge {
             Some(_c) => Ok(()),
-            None => Err(crate::error::Error::ChallengeError(
+            None => Err(crate::error::Error::Challenge(
                 crate::error::ChallengeErrorKind::ChallengeNotFound,
             )),
         }

--- a/rust-keybroker/keybroker-server/src/error.rs
+++ b/rust-keybroker/keybroker-server/src/error.rs
@@ -1,0 +1,27 @@
+// Copyright 2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+use thiserror::Error;
+
+/// Top-level error type for the whole of the key broker service.
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    VeraisonApiError(#[from] veraison_apiclient::Error),
+
+    #[error(transparent)]
+    EarError(#[from] ear::Error),
+
+    #[error(transparent)]
+    VerificationError(#[from] VerificationErrorKind),
+}
+
+/// Errors happening within the verification process logic.
+#[derive(Error, Debug)]
+pub enum VerificationErrorKind {
+    /// It was not possible to find the challenge-response newSession endpoint
+    #[error("No newChallengeResponseSession endpoint was found on the Veraison server.")]
+    NoChallengeResponseEndpoint,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/rust-keybroker/keybroker-server/src/error.rs
+++ b/rust-keybroker/keybroker-server/src/error.rs
@@ -14,6 +14,15 @@ pub enum Error {
 
     #[error(transparent)]
     VerificationError(#[from] VerificationErrorKind),
+
+    #[error(transparent)]
+    RsaError(#[from] rsa::Error),
+
+    #[error(transparent)]
+    KeyStoreError(#[from] KeyStoreErrorKind),
+
+    #[error(transparent)]
+    Base64DecodeError(#[from] base64::DecodeError),
 }
 
 /// Errors happening within the verification process logic.
@@ -22,6 +31,20 @@ pub enum VerificationErrorKind {
     /// It was not possible to find the challenge-response newSession endpoint
     #[error("No newChallengeResponseSession endpoint was found on the Veraison server.")]
     NoChallengeResponseEndpoint,
+}
+
+/// Errors happening within the key store.
+#[derive(Error, Debug)]
+pub enum KeyStoreErrorKind {
+    /// Attempt to obtain a key that is not in the store.
+    #[error("Requested key is not in the store.")]
+    KeyNotFound,
+
+    #[error("The wrapping key type is not supported. Wrapping key must be an RSA key.")]
+    UnsupportedWrappingKeyType,
+
+    #[error("Thw wrapping key encryption algorithm is not supported.")]
+    UnsupportedWrappingKeyAlgorithm,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/rust-keybroker/keybroker-server/src/error.rs
+++ b/rust-keybroker/keybroker-server/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
     KeyStoreError(#[from] KeyStoreErrorKind),
 
     #[error(transparent)]
+    ChallengeError(#[from] ChallengeErrorKind),
+
+    #[error(transparent)]
     Base64DecodeError(#[from] base64::DecodeError),
 }
 
@@ -45,6 +48,14 @@ pub enum KeyStoreErrorKind {
 
     #[error("Thw wrapping key encryption algorithm is not supported.")]
     UnsupportedWrappingKeyAlgorithm,
+}
+
+/// Errors related to the management of challenges
+#[derive(Error, Debug)]
+pub enum ChallengeErrorKind {
+    /// Attempt to lookup a challenge with an unknown ID.
+    #[error("Reference to a challenge that does not exist.")]
+    ChallengeNotFound,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/rust-keybroker/keybroker-server/src/error.rs
+++ b/rust-keybroker/keybroker-server/src/error.rs
@@ -6,24 +6,35 @@ use thiserror::Error;
 /// Top-level error type for the whole of the key broker service.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Represents errors resulting from the Veraison API usage (when the keybroker calls out to Veraison to verify attestation tokens).
     #[error(transparent)]
     VeraisonApi(#[from] veraison_apiclient::Error),
 
+    /// Represents errors from the use of the attestation results library. These errors may occur when inspecting attestation
+    /// results in order to implement an appraisal policy.
     #[error(transparent)]
     Ear(#[from] ear::Error),
 
+    /// Represents errors in verification that are not API usage errors.
     #[error(transparent)]
     Verification(#[from] VerificationErrorKind),
 
+    /// Represents errors related to RSA encryption or decryption. These can occur when using the RSA algorithm to wrap
+    /// key data from the server.
     #[error(transparent)]
     Rsa(#[from] rsa::Error),
 
+    /// Represents an error from the key store, such as an attempt to access a key that does not exist.
     #[error(transparent)]
     KeyStore(#[from] KeyStoreErrorKind),
 
+    /// Represents an error from the challenge manager, such as an attempt to lookup a challenge that was
+    /// never allocated.
     #[error(transparent)]
     Challenge(#[from] ChallengeErrorKind),
 
+    /// Represents errors related to base64 decoding, which can occur when processing the various base64 strings
+    /// that are transacted through the API between the client and the server, if the client provides faulty data.
     #[error(transparent)]
     Base64Decode(#[from] base64::DecodeError),
 }
@@ -43,9 +54,11 @@ pub enum KeyStoreErrorKind {
     #[error("Requested key is not in the store.")]
     KeyNotFound,
 
+    /// The client provided a wrapping key that is not an RSA key.
     #[error("The wrapping key type is not supported. Wrapping key must be an RSA key.")]
     UnsupportedWrappingKeyType,
 
+    /// The client provided a wrapping key whose algorithm was not supported.
     #[error("Thw wrapping key encryption algorithm is not supported.")]
     UnsupportedWrappingKeyAlgorithm,
 }

--- a/rust-keybroker/keybroker-server/src/error.rs
+++ b/rust-keybroker/keybroker-server/src/error.rs
@@ -7,25 +7,25 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    VeraisonApiError(#[from] veraison_apiclient::Error),
+    VeraisonApi(#[from] veraison_apiclient::Error),
 
     #[error(transparent)]
-    EarError(#[from] ear::Error),
+    Ear(#[from] ear::Error),
 
     #[error(transparent)]
-    VerificationError(#[from] VerificationErrorKind),
+    Verification(#[from] VerificationErrorKind),
 
     #[error(transparent)]
-    RsaError(#[from] rsa::Error),
+    Rsa(#[from] rsa::Error),
 
     #[error(transparent)]
-    KeyStoreError(#[from] KeyStoreErrorKind),
+    KeyStore(#[from] KeyStoreErrorKind),
 
     #[error(transparent)]
-    ChallengeError(#[from] ChallengeErrorKind),
+    Challenge(#[from] ChallengeErrorKind),
 
     #[error(transparent)]
-    Base64DecodeError(#[from] base64::DecodeError),
+    Base64Decode(#[from] base64::DecodeError),
 }
 
 /// Errors happening within the verification process logic.

--- a/rust-keybroker/keybroker-server/src/keystore.rs
+++ b/rust-keybroker/keybroker-server/src/keystore.rs
@@ -1,0 +1,70 @@
+// Copyright 2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::prelude::*;
+use keybroker_common::PublicWrappingKey;
+use rsa::{BigUint, Pkcs1v15Encrypt, RsaPublicKey};
+
+use crate::error::Result;
+use std::collections::HashMap;
+
+/// A minimally simple key-value store where the lookup keys are strings and the values
+/// are byte arrays (octet vectors).
+///
+/// The byte arrays are typically intended to be encryption keys, which is why this
+/// structure is called a "key store", so take care not to confuse the lookup keys
+/// (which are strings) with the values, since the term "key" can be ambiguous.
+///
+/// The byte arrays do not necessarily need to be encryption keys. They could be other small
+/// secret data blobs. However, whatever they are, they should be small, because they
+/// are treated using asymmetric encryption methods. Do not store very large data
+/// blobs in this store. It is only intended to demonstrate the retrieval of secrets
+/// in confidential computing contexts.
+///
+/// Data is never revealed in plaintext - only the `wrap()` function is used, which
+/// encrypts data with a given public key.
+pub struct KeyStore {
+    keys: HashMap<String, Vec<u8>>,
+}
+
+impl KeyStore {
+    /// Create a new, empty key store
+    pub fn new() -> KeyStore {
+        KeyStore {
+            keys: HashMap::new(),
+        }
+    }
+
+    /// Store a new key in the key store.
+    ///
+    /// Key data here is provided as plain text. That's because this is an initialization
+    /// function that is only used by the internals of the key broker to build the contents
+    /// of the store from trusted internal sources, such as command-line arguments or a local
+    /// configuration file.
+    pub fn store_key(&mut self, key_id: &String, data: Vec<u8>) -> () {
+        self.keys.insert(key_id.clone(), data.clone());
+    }
+
+    /// Obtain a wrapped (encrypted) data item from the store.
+    pub fn wrap_key(&self, key_id: &String, wrapping_key: &PublicWrappingKey) -> Result<Vec<u8>> {
+        let k_mod = URL_SAFE_NO_PAD.decode(&wrapping_key.n)?;
+        let n = BigUint::from_bytes_be(&k_mod);
+        let k_exp = URL_SAFE_NO_PAD.decode(&wrapping_key.e)?;
+        let e = BigUint::from_bytes_be(&k_exp);
+
+        let mut rng = rand::thread_rng();
+
+        let rsa_pub_key = RsaPublicKey::new(n, e)?;
+
+        if let Some(entry) = self.keys.get_key_value(key_id) {
+            let (_k, data) = entry;
+            let wrapped_data = rsa_pub_key.encrypt(&mut rng, Pkcs1v15Encrypt, data)?;
+            Ok(wrapped_data)
+        } else {
+            Err(crate::error::Error::KeyStoreError(
+                crate::error::KeyStoreErrorKind::KeyNotFound,
+            ))
+        }
+    }
+}

--- a/rust-keybroker/keybroker-server/src/keystore.rs
+++ b/rust-keybroker/keybroker-server/src/keystore.rs
@@ -47,8 +47,8 @@ impl KeyStore {
     /// function that is only used by the internals of the key broker to build the contents
     /// of the store from trusted internal sources, such as command-line arguments or a local
     /// configuration file.
-    pub fn store_key(&mut self, key_id: &String, data: Vec<u8>) -> () {
-        self.keys.insert(key_id.clone(), data.clone());
+    pub fn store_key(&mut self, key_id: &str, data: Vec<u8>) {
+        self.keys.insert(key_id.to_owned(), data.clone());
     }
 
     /// Obtain a wrapped (encrypted) data item from the store.
@@ -58,7 +58,7 @@ impl KeyStore {
         wrapping_key: &PublicWrappingKey,
     ) -> Result<WrappedKeyData> {
         if wrapping_key.kty != *RSA_KEY_TYPE {
-            return Err(crate::error::Error::KeyStoreError(
+            return Err(crate::error::Error::KeyStore(
                 crate::error::KeyStoreErrorKind::UnsupportedWrappingKeyType,
             ));
         }
@@ -81,7 +81,7 @@ impl KeyStore {
                     let padding = Oaep::new::<Sha256>();
                     rsa_pub_key.encrypt(&mut rng, padding, data)
                 } else {
-                    return Err(crate::error::Error::KeyStoreError(
+                    return Err(crate::error::Error::KeyStore(
                         crate::error::KeyStoreErrorKind::UnsupportedWrappingKeyAlgorithm,
                     ));
                 }
@@ -90,7 +90,7 @@ impl KeyStore {
             let retobj = WrappedKeyData { data: data_base64 };
             Ok(retobj)
         } else {
-            Err(crate::error::Error::KeyStoreError(
+            Err(crate::error::Error::KeyStore(
                 crate::error::KeyStoreErrorKind::KeyNotFound,
             ))
         }
@@ -108,7 +108,7 @@ mod tests {
         // Put a key into the store
         let key_id = "skywalker";
         let key_content = "May the force be with you.";
-        store.store_key(&key_id.to_string(), key_content.as_bytes().to_vec());
+        store.store_key(key_id, key_content.as_bytes().to_vec());
 
         // Create an ephemeral wrapping key-pair
         let mut rng = rand::thread_rng();

--- a/rust-keybroker/keybroker-server/src/main.rs
+++ b/rust-keybroker/keybroker-server/src/main.rs
@@ -1,6 +1,100 @@
 // Copyright 2024 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
-fn main() {
-    println!("Hello, world!");
+use actix_web::{get, http, post, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
+use base64::prelude::*;
+use keybroker_common::{
+    AttestationChallenge, BackgroundCheckKeyRequest, ErrorInformation, WrappedKeyData,
+};
+
+mod verifier;
+
+// This is the challenge value from from https://git.trustedfirmware.org/TF-M/tf-m-tools/+/refs/heads/main/iat-verifier/tests/data/cca_example_token.cbor
+const CCA_EXAMPLE_TOKEN_NONCE: &'static [u8] = &[
+    0x6e, 0x86, 0xd6, 0xd9, 0x7c, 0xc7, 0x13, 0xbc, 0x6d, 0xd4, 0x3d, 0xbc, 0xe4, 0x91, 0xa6, 0xb4,
+    0x03, 0x11, 0xc0, 0x27, 0xa8, 0xbf, 0x85, 0xa3, 0x9d, 0xa6, 0x3e, 0x9c, 0xe4, 0x4c, 0x13, 0x2a,
+    0x8a, 0x11, 0x9d, 0x29, 0x6f, 0xae, 0x6a, 0x69, 0x99, 0xe9, 0xbf, 0x3e, 0x44, 0x71, 0xb0, 0xce,
+    0x01, 0x24, 0x5d, 0x88, 0x94, 0x24, 0xc3, 0x1e, 0x89, 0x79, 0x3b, 0x3b, 0x1d, 0x6b, 0x15, 0x04,
+];
+
+#[post("/key/{keyid}")]
+async fn request_key(
+    path: web::Path<String>,
+    key_request: web::Json<BackgroundCheckKeyRequest>,
+) -> impl Responder {
+    let key_id = path.into_inner();
+
+    // TODO: Mock implementation for now
+    let attestation_challenge = AttestationChallenge {
+        challenge: BASE64_STANDARD.encode(CCA_EXAMPLE_TOKEN_NONCE),
+        accept: vec![
+            "application/eat-collection; profile=http://arm.com/CCA-SSD/1.0.0".to_string(),
+        ],
+    };
+
+    HttpResponse::Created().json(attestation_challenge)
+}
+
+#[post("/evidence/{challengeid}")]
+async fn submit_evidence(
+    path: web::Path<String>,
+    request: HttpRequest,
+    evidence_base64: String,
+) -> impl Responder {
+    let challenge_id = path.into_inner();
+    let default_content_type = http::header::HeaderValue::from_static("application/string");
+
+    let content_type = request
+        .headers()
+        .get(http::header::CONTENT_TYPE)
+        .unwrap_or(&default_content_type);
+
+    let evidence_bytes = BASE64_STANDARD.decode(evidence_base64).unwrap(); // TODO: Error handling needed here in case of faulty base64 input
+
+    /*
+
+    (verification not working yet)
+
+    // TODO: Allow the veraison endpoint to be configurable. Currently using the Linaro-provided instance for emulated platforms.
+    // TODO: Use the media content type from the request's Content-Type header - currently not doing that because actix_web doesn't like the CCA media type
+    // TODO: Use of hard-coded nonce here - temporary until we have proper sessions based on the key request
+    let verified = verifier::verify_with_veraison_instance(
+        "http://veraison.test.linaro.org:8080",
+        "application/eat-collection; profile=http://arm.com/CCA-SSD/1.0.0",
+        CCA_EXAMPLE_TOKEN_NONCE,
+        &evidence_bytes,
+    );
+    */
+
+    let verified = true;
+
+    // Switch on whether the evidence was successfully verified or not.
+    if verified {
+        // TODO: The attestation is valid - so wrap a key out of the key store here. Currently returning a dummy response that is not encrypted at all.
+        let wrapped_key = WrappedKeyData {
+            data: "May the force be with you".to_string(),
+        };
+
+        HttpResponse::Ok().json(wrapped_key)
+    } else {
+        let error_info = ErrorInformation {
+            r#type: "AttestationFailure".to_string(),
+            detail: "The attestation failed.".to_string(),
+        };
+
+        HttpResponse::Forbidden().json(error_info)
+    }
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        let scope = web::scope("/keys/v1")
+            .service(request_key)
+            .service(submit_evidence);
+        App::new().service(scope)
+    })
+    .bind(("127.0.0.1", 8088))?
+    .run()
+    .await
 }

--- a/rust-keybroker/keybroker-server/src/main.rs
+++ b/rust-keybroker/keybroker-server/src/main.rs
@@ -7,6 +7,7 @@ use keybroker_common::{
     AttestationChallenge, BackgroundCheckKeyRequest, ErrorInformation, WrappedKeyData,
 };
 
+mod error;
 mod verifier;
 
 // This is the challenge value from from https://git.trustedfirmware.org/TF-M/tf-m-tools/+/refs/heads/main/iat-verifier/tests/data/cca_example_token.cbor

--- a/rust-keybroker/keybroker-server/src/main.rs
+++ b/rust-keybroker/keybroker-server/src/main.rs
@@ -9,6 +9,7 @@ use clap::Parser;
 use keybroker_common::{
     AttestationChallenge, BackgroundCheckKeyRequest, ErrorInformation, WrappedKeyData,
 };
+mod challenge;
 mod error;
 mod keystore;
 mod verifier;

--- a/rust-keybroker/keybroker-server/src/main.rs
+++ b/rust-keybroker/keybroker-server/src/main.rs
@@ -3,9 +3,7 @@
 
 use std::sync::Mutex;
 
-use actix_web::{
-    get, http, post, rt::task, web, App, HttpRequest, HttpResponse, HttpServer, Responder,
-};
+use actix_web::{http, post, rt::task, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::prelude::*;
 use challenge::Challenger;
@@ -63,7 +61,7 @@ async fn submit_evidence(
     let mut challenger = data.challenger.lock().expect("Poisoned challenger lock.");
     let challenge = challenger.get_challenge(challenge_id);
 
-    if (challenge.is_err()) {
+    if challenge.is_err() {
         let error_info = ErrorInformation {
             r#type: "AttestationFailure".to_string(),
             detail: "The challenge identifier did not match any issued challenge.".to_string(),
@@ -78,7 +76,8 @@ async fn submit_evidence(
     // Once the evidence is submitted, delete the challenge. It can't be used again.
     challenger.delete_challenge(challenge_id).unwrap();
 
-    let content_type = request
+    // TODO: We are currently ignoring the content type from the request and assuming a CCA eat-collection.
+    let _content_type = request
         .headers()
         .get(http::header::CONTENT_TYPE)
         .unwrap_or(&default_content_type);

--- a/rust-keybroker/keybroker-server/src/main.rs
+++ b/rust-keybroker/keybroker-server/src/main.rs
@@ -5,10 +5,10 @@ use actix_web::{
     get, http, post, rt::task, web, App, HttpRequest, HttpResponse, HttpServer, Responder,
 };
 use base64::prelude::*;
+use clap::Parser;
 use keybroker_common::{
     AttestationChallenge, BackgroundCheckKeyRequest, ErrorInformation, WrappedKeyData,
 };
-
 mod error;
 mod keystore;
 mod verifier;
@@ -100,15 +100,26 @@ async fn submit_evidence(
     }
 }
 
+/// Structure for parsing and storing the command-line arguments
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// The port on which the web server will listen
+    #[arg(short, long, default_value_t = 8088)]
+    port: u16,
+}
+
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    let args = Args::parse();
+
     HttpServer::new(|| {
         let scope = web::scope("/keys/v1")
             .service(request_key)
             .service(submit_evidence);
         App::new().service(scope)
     })
-    .bind(("127.0.0.1", 8088))?
+    .bind(("127.0.0.1", args.port))?
     .run()
     .await
 }

--- a/rust-keybroker/keybroker-server/src/main.rs
+++ b/rust-keybroker/keybroker-server/src/main.rs
@@ -56,7 +56,7 @@ async fn submit_evidence(
     evidence_base64: String,
 ) -> impl Responder {
     let challenge_id = path.into_inner();
-    let default_content_type = http::header::HeaderValue::from_static("application/string");
+    let default_content_type = http::header::HeaderValue::from_static("text/plain");
 
     let challenge = {
         let mut challenger = data.challenger.lock().expect("Poisoned challenger lock.");

--- a/rust-keybroker/keybroker-server/src/main.rs
+++ b/rust-keybroker/keybroker-server/src/main.rs
@@ -10,6 +10,7 @@ use keybroker_common::{
 };
 
 mod error;
+mod keystore;
 mod verifier;
 
 // This is the challenge value from from https://git.trustedfirmware.org/TF-M/tf-m-tools/+/refs/heads/main/iat-verifier/tests/data/cca_example_token.cbor

--- a/rust-keybroker/keybroker-server/src/main.rs
+++ b/rust-keybroker/keybroker-server/src/main.rs
@@ -85,14 +85,14 @@ async fn submit_evidence(
 
     let evidence_bytes = URL_SAFE_NO_PAD.decode(evidence_base64).unwrap(); // TODO: Error handling needed here in case of faulty base64 input
 
+    let verifier_base = data.args.verifier.clone();
+
     // We are in an async context, but the verifier client is synchronous, so spawn
     // it as a blocking task.
     let handle = task::spawn_blocking(move || {
-        // TODO: Allow the veraison endpoint to be configurable. Currently using the Linaro-provided instance for emulated platforms.
         // TODO: Use the media content type from the request's Content-Type header - currently not doing that because actix_web doesn't like the CCA media type
-        // TODO: Use of hard-coded nonce here - temporary until we have proper sessions based on the key request
         verifier::verify_with_veraison_instance(
-            "http://veraison.test.linaro.org:8080",
+            &verifier_base,
             "application/eat-collection; profile=http://arm.com/CCA-SSD/1.0.0",
             &challenge.challenge_value,
             &evidence_bytes,
@@ -141,6 +141,9 @@ struct Args {
 
     #[arg(short, long, default_value = "http://127.0.0.1")]
     baseurl: String,
+
+    #[arg(short, long, default_value = "http://veraison.test.linaro.org:8080")]
+    verifier: String,
 }
 
 struct ServerState {

--- a/rust-keybroker/keybroker-server/src/verifier.rs
+++ b/rust-keybroker/keybroker-server/src/verifier.rs
@@ -1,0 +1,61 @@
+// Copyright 2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+use ear::{Algorithm, Ear, TrustTier};
+use veraison_apiclient::*;
+
+pub fn verify_with_veraison_instance(
+    verifier_base_url: &str,
+    media_type: &str,
+    challenge: &[u8],
+    evidence: &[u8],
+) -> bool {
+    // Get the discovery URL from the base URL
+    let discovery = Discovery::from_base_url(String::from(verifier_base_url))
+        .expect("Failed to start API discovery with the service.");
+
+    // Quiz the discovery endpoint for the verification endpoint
+    let verification_api = discovery
+        .get_verification_api()
+        .expect("Failed to discover the verification endpoint details.");
+
+    // Get the challenge-response endpoint from the verification endpoint
+    let relative_endpoint = verification_api
+        .get_api_endpoint("newChallengeResponseSession")
+        .expect("Could not locate a newChallengeResponseSession endpoint.");
+
+    let api_endpoint = format!("{}{}", verifier_base_url, relative_endpoint);
+
+    // create a ChallengeResponse object
+    let cr = ChallengeResponseBuilder::new()
+        .with_new_session_url(api_endpoint)
+        .build()
+        .unwrap();
+
+    let nonce = Nonce::Value(challenge.to_vec());
+
+    let (session_url, _session) = cr.new_session(&nonce).unwrap();
+
+    // Run the challenge-response session
+    let ear_string = cr
+        .challenge_response(evidence, media_type, &session_url)
+        .unwrap();
+
+    // EARs are signed by Veraison. The public verification key is conveyed within the
+    // endpoint descriptor that we pulled from the discovery API before. We can grab this
+    // as a JSON string, which will allow us to start using the rust-ear library to
+    // parse and inspect the EAR token.
+    let verification_key_string = verification_api.ear_verification_key_as_string();
+
+    // We've finished talking to Veraison at this point. The rest of the code is concerned with
+    // locally inspecting the EAR. We now start using the rust-ear library
+    // from https://github.com/veraison/rust-ear
+    // We start by getting the Ear structure from the JWT, which also does a signature
+    // check.
+    let ear =
+        Ear::from_jwt_jwk(&ear_string, Algorithm::ES256, verification_key_string.as_bytes()).unwrap();
+
+    // The simplest possible appraisal policy: accept if we have an AFFIRMING result from
+    // every submodule of the token.
+    ear.submods.iter().all(|(_module, appraisal)| appraisal.status == TrustTier::Affirming)
+}

--- a/rust-keybroker/keybroker-server/src/verifier.rs
+++ b/rust-keybroker/keybroker-server/src/verifier.rs
@@ -21,7 +21,7 @@ pub fn verify_with_veraison_instance(
     let relative_endpoint = verification_api.get_api_endpoint("newChallengeResponseSession");
 
     if relative_endpoint.is_none() {
-        return Err(crate::error::Error::VerificationError(
+        return Err(crate::error::Error::Verification(
             crate::error::VerificationErrorKind::NoChallengeResponseEndpoint,
         ));
     }


### PR DESCRIPTION
feat: First functional chunk of code for the key broker server.

Implements the documented API, but with various limitations and TODOs. It provides enough that it can be tested and demonstrated.

Only supports Arm CCA attestation at the moment, although this restriction would be easy to lift.

The nonce/challenge value is currently hardcoded and not properly randomised. This allows the server to be tested with a mock client that just replays pre-baked CCA example tokens. Once we have a working client that gets real attestation tokens from the system, we can move to using properly randomised nonces.

The key broker stores a single key called "skywalker", and its value decodes to "May the force be with you.". This is hard-coded in the initialisation path at the moment. It would be better to read these from an input config file so that multiple keys can be stored.

Signed-off-by: Paul Howard <paul.howard@arm.com>