### PR TITLE
fix: Temporarily allow WARNING as well as AFFIRMING status in EAR submodules

### DIFF
--- a/rust-keybroker/keybroker-server/src/verifier.rs
+++ b/rust-keybroker/keybroker-server/src/verifier.rs
@@ -60,12 +60,14 @@ pub fn verify_with_veraison_instance(
         verification_key_string.as_bytes(),
     )?;
 
-    // The simplest possible appraisal policy: accept if we have an AFFIRMING result from
-    // every submodule of the token.
-    let verified = ear
-        .submods
-        .iter()
-        .all(|(_module, appraisal)| appraisal.status == TrustTier::Affirming);
+    // The simplest possible appraisal policy: accept if we have an AFFIRMING or WARNING result
+    // from every submodule.
+    // TODO: This policy is rather too "relaxed" - the simplest and strictest policy would be
+    //       to require AFFIRMING from every submodule. We have some integration issues with Veraison
+    //       today that prevent this.
+    let verified = ear.submods.iter().all(|(_module, appraisal)| {
+        appraisal.status == TrustTier::Affirming || appraisal.status == TrustTier::Warning
+    });
 
     Ok(verified)
 }


### PR DESCRIPTION
Small tweak to the EAR eval logic that gates whether the wrapped secret is released to the caller.

The algorithm remains ultra-simple and neutral with respect to AR submodule composition. The previous algorithm required an `affirming` status from every submodule. The new one allows `warning` as well. This isn't exactly desirable, but it keeps the key broker working while we handle some deeper issues around CCA realm/workload attestation, which was recently added to Veraison.

Signed-off-by: Paul Howard <paul.howard@arm.com>