### PR TITLE
feat: use Rust standard logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ values).
 In a terminal, start `keybroker-server` with:
 
 ```console
-$ target/debug/keybroker-server -v -m --reference-values ../testdata/rims-matching.json
+$ target/debug/keybroker-server -v -m --reference-values <(echo '{ "reference-values": [ "MRMUq3NiA1DPdYg0rlxl2ejC3H/r5ufZZUu+hk4wDUk=" ] }')
 INFO starting 11 workers
 INFO Actix runtime found; starting in Actix runtime
 INFO starting service: "actix-web-service-127.0.0.1:8088", workers: 11, listening on: 127.0.0.1:8088

--- a/README.md
+++ b/README.md
@@ -13,3 +13,94 @@ flowchart LR
     RP -->|Evidence fa:fa-receipt| V[Veraison]
     V -->|EAR fa:fa-check-square| RP
 ```
+
+## Building
+
+The `keybroker-demo` has 2 executables: `keybroker-server` and `keybroker-app`.
+These are built with:
+
+```console
+$ cd rust-keybroker
+$ cargo build
+```
+
+By default, the executables are in debug mode and located in directory
+`target/debug/`.
+
+## Running
+
+The `keybroker-server` and `keybroker-app` can be controlled with command line
+options. Use `-h` / `--help` to get their usage, e.g.:
+
+```
+$ target/debug/keybroker-server --help
+A simple web service that can provide keys and secrets in exchange for verifiable attestation tokens.
+
+Usage: keybroker-server [OPTIONS]
+
+Options:
+  -a, --addr <ADDR>
+          The interface on which this server will listen (use 0.0.0.0 to listen on all interfaces) [default: 127.0.0.1]
+  -p, --port <PORT>
+          The port on which this server will listen [default: 8088]
+  -e, --endpoint <ENDPOINT>
+          The address at which this server can be reached to request a key or submit an evidence. It will be set by default to 'http://{addr}', but this value can be overridden with an FQDN for {addr} in order to use name resolution for example. The port number will be appended, so don't leave a trailing '/' to the FQDN
+      --verifier <VERIFIER>
+          The URL where the verifier can be reached [default: http://veraison.test.linaro.org:8080]
+  -m, --mock-challenge
+          Use the static CCA example token nonce instead of a randomly generated one
+  -v, --verbosity...
+          Increase verbosity
+  -q, --quiet
+          Silence all output
+      --reference-values <REFERENCE_VALUES>
+          File containing a JSON array with base64-encoded known-good RIM values [default: reference-values.json]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
+```
+
+The simplest way to get started with `keybroker-server` and `keybroker-app` is
+to run them locally in _mocking_ mode (i.e they make use of statically known
+values).
+
+In a terminal, start `keybroker-server` with:
+
+```console
+$ target/debug/keybroker-server -v -m --reference-values ../testdata/rims-matching.json
+INFO starting 11 workers
+INFO Actix runtime found; starting in Actix runtime
+INFO starting service: "actix-web-service-127.0.0.1:8088", workers: 11, listening on: 127.0.0.1:8088
+```
+
+In another terminal, launch `keybroker-app` with:
+
+```console
+$ target/debug/keybroker-app -v -m skywalker
+INFO Requesting key named 'skywalker' from the keybroker server with URL http://127.0.0.1:8088/keys/v1/key/skywalker
+INFO Submitting evidence to URL http://127.0.0.1:8088/keys/v1/evidence/1923965078
+INFO Attestation success :-) ! The key returned from the keybroker is 'May the force be with you.'
+```
+
+`keybroker-app` is requesting the key named `skywalker` from `keybroker-server`.
+As we are in _mocking_ mode with statically known challenges and evidences, the
+attestation succeeds: `keyboker-app` receives the key `May the force be with
+you.` from `keybroker-server`.
+
+## Logging
+
+`keybroker-server` and `keybroker-app` use Rust's `log` and `stderrlog` crates
+for logging. the verbosity can be controlled from the command line with the `-q`
+/ `--quiet` (to silence all messages) and `-v` / `--verbose` switches. Note the
+`-v` / `--verbose` can be specified multiple times to increase verbosity.
+
+The mapping that has been implemented in `keybroker-server` and `keybroker-app` is:
+
+| Log level | Verbosity threshold | `keybroker-*`                                            |
+| --------- | ------------------- | -------------------------------------------------------- |
+| Error     |          0          | Enabled by default, unless invoked with `-q` / `--quiet` |
+| Warning   |	       1          | Enabled by default, unless invoked with `-q` / `--quiet` |
+| Info 	    |          2          | Enabled with `-v` or `--verbose`                         |
+| Debug     |          3          | Enabled with `-vv` or `-v -v` or `--verbose --verbose`   |
+| Trace     |          4          | Enabled with `-vvv` or `-v -v -v` or ...                 |

--- a/rust-keybroker/keybroker-app/Cargo.toml
+++ b/rust-keybroker/keybroker-app/Cargo.toml
@@ -13,3 +13,5 @@ categories = ["cryptography", "hardware-support"]
 [dependencies]
 keybroker-client = { path = "../keybroker-client" }
 clap = { version = "=4.3.24", features = ["derive", "std"] }
+log = { version = "0.4.22", features = ["std", "serde"] }
+stderrlog = "0.6.0"

--- a/rust-keybroker/keybroker-client/Cargo.toml
+++ b/rust-keybroker/keybroker-client/Cargo.toml
@@ -13,8 +13,10 @@ categories = ["cryptography", "hardware-support"]
 [dependencies]
 keybroker-common = { path = "../keybroker-common" }
 base64 = "0.22.1"
+log = { version = "0.4.22", features = ["std", "serde"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.5", features = ["json", "rustls-tls", "blocking"] }
 rsa = "0.9.6"
+stderrlog = "0.6.0"
 thiserror = "1.0"
 tsm_report = { git = "https://github.com/veracruz-project/cca-utils-rs.git", rev = "cb88b76da722f2991365b159e3d575249dfbbe7d"}

--- a/rust-keybroker/keybroker-server/Cargo.toml
+++ b/rust-keybroker/keybroker-server/Cargo.toml
@@ -26,3 +26,5 @@ regorus = "0.2.5"
 serde_json = "1.0.128"
 anyhow = "1.0.89"
 phf = "0.11.2"
+log = { version = "0.4.22", features = ["std", "serde"] }
+stderrlog = "0.6.0"

--- a/rust-keybroker/keybroker-server/src/challenge.rs
+++ b/rust-keybroker/keybroker-server/src/challenge.rs
@@ -45,7 +45,6 @@ pub struct Challenge {
 pub struct Challenger {
     challenge_table: HashMap<u32, Challenge>,
     rng: StdRng,
-    pub verbose: bool,
 }
 
 // This is the challenge value from from https://git.trustedfirmware.org/TF-M/tf-m-tools/+/refs/heads/main/iat-verifier/tests/data/cca_example_token.cbor
@@ -63,7 +62,6 @@ impl Challenger {
         Challenger {
             challenge_table: HashMap::new(),
             rng: StdRng::from_entropy(),
-            verbose: false,
         }
     }
 
@@ -101,16 +99,16 @@ impl Challenger {
 
         self.challenge_table.insert(challenge_id, challenge.clone());
 
-        if self.verbose {
-            println!("Created challenge:");
-            println!(" - challenge_id: {}", challenge_id);
-            println!(" - key_id: {}", challenge.key_id);
-            println!(
-                " - challenge value ({} bytes): {:02x?}",
-                challenge.challenge_value.len(),
-                challenge.challenge_value
-            );
-        }
+        log::info!(
+            "Created challenge:\n\
+              - challenge_id: {}\n\
+              - key_id: {}\n\
+              - challenge value ({} bytes): {:02x?}",
+            challenge_id,
+            challenge.key_id,
+            challenge.challenge_value.len(),
+            challenge.challenge_value
+        );
 
         challenge
     }


### PR DESCRIPTION
This commit removes all the "println" that were in the repository to use Rust's standard "log" crate instead (which is maitained by the Rust core team).

All the library / infrastructure parts of the keybroker-demo repository only use the "log::error", "log::warn", "log::info", "log::debug" functions from the logging facade.

The actual executables (keybroker-server, keybroker-app) instantiate and configure an implementation of a logger.  The stderrlog implementation is used here as it is simple minimal logger, but https://docs.rs/log/latest/log/ lists many more available logging implementations.

The keybroker-server and keyborker-app do use the same command line options with respect to logging control (verbose / quiet). The verbose switch can be specified multiple times to increase verbosity.