### PR TITLE
refactor: improve dependency management.

### DIFF
--- a/rust-keybroker/Cargo.toml
+++ b/rust-keybroker/Cargo.toml
@@ -6,3 +6,24 @@ members = [
     "keybroker-server",
     "keybroker-app",
 ]
+
+[workspace.dependencies]
+actix-web = "4"
+anyhow = "1.0.89"
+base64 = "0.22.1"
+clap = { version = "=4.3.24", features = ["derive", "std"] }
+ear = { git = "https://github.com/veraison/rust-ear.git" }
+log = { version = "0.4.22", features = ["std", "serde"] }
+phf = "0.11.2"
+rand = "0.8.5"
+regorus = "0.2.5"
+reqwest = { version = "0.12.5", features = ["json", "rustls-tls", "blocking"] }
+rsa = "0.9.6"
+serde = "1.0.204"
+serde_json = "1.0.128"
+serde_with = "3.9.0"
+sha2 = "0.10.8"
+stderrlog = "0.6.0"
+thiserror = "1.0.63"
+tsm_report = { git = "https://github.com/veracruz-project/cca-utils-rs.git", rev = "cb88b76da722f2991365b159e3d575249dfbbe7d"}
+veraison-apiclient = { git = "https://github.com/veraison/rust-apiclient.git" }

--- a/rust-keybroker/keybroker-app/Cargo.toml
+++ b/rust-keybroker/keybroker-app/Cargo.toml
@@ -12,6 +12,6 @@ categories = ["cryptography", "hardware-support"]
 
 [dependencies]
 keybroker-client = { path = "../keybroker-client" }
-clap = { version = "=4.3.24", features = ["derive", "std"] }
-log = { version = "0.4.22", features = ["std", "serde"] }
-stderrlog = "0.6.0"
+clap.workspace = true
+log.workspace = true
+stderrlog.workspace = true

--- a/rust-keybroker/keybroker-client/Cargo.toml
+++ b/rust-keybroker/keybroker-client/Cargo.toml
@@ -12,11 +12,11 @@ categories = ["cryptography", "hardware-support"]
 
 [dependencies]
 keybroker-common = { path = "../keybroker-common" }
-base64 = "0.22.1"
-log = { version = "0.4.22", features = ["std", "serde"] }
-rand = "0.8.5"
-reqwest = { version = "0.12.5", features = ["json", "rustls-tls", "blocking"] }
-rsa = "0.9.6"
-stderrlog = "0.6.0"
-thiserror = "1.0"
-tsm_report = { git = "https://github.com/veracruz-project/cca-utils-rs.git", rev = "cb88b76da722f2991365b159e3d575249dfbbe7d"}
+base64.workspace = true
+log.workspace = true
+rand.workspace = true
+reqwest.workspace = true
+rsa.workspace = true
+stderrlog.workspace = true
+thiserror.workspace = true
+tsm_report.workspace = true

--- a/rust-keybroker/keybroker-common/Cargo.toml
+++ b/rust-keybroker/keybroker-common/Cargo.toml
@@ -11,5 +11,5 @@ keywords = ["security", "service", "attestation"]
 categories = ["cryptography", "hardware-support"]
 
 [dependencies]
-serde = { version = "1.0.204", features = ["serde_derive"] }
-serde_with = "3.9.0"
+serde.workspace = true
+serde_with.workspace = true

--- a/rust-keybroker/keybroker-server/Cargo.toml
+++ b/rust-keybroker/keybroker-server/Cargo.toml
@@ -11,20 +11,20 @@ keywords = ["security", "service", "attestation"]
 categories = ["cryptography", "hardware-support"]
 
 [dependencies]
-actix-web = "4"
-base64 = "0.22.1"
-thiserror = "1.0.63"
-serde = "1.0.204"
-rsa = "0.9.6"
-sha2 = "0.10.8"
-rand = "0.8.5"
-clap = { version = "=4.3.24", features = ["derive", "std"] }
 keybroker-common = { path = "../keybroker-common" }
-veraison-apiclient = { git = "https://github.com/veraison/rust-apiclient.git" }
-ear = { git = "https://github.com/veraison/rust-ear.git" }
-regorus = "0.2.5"
-serde_json = "1.0.128"
-anyhow = "1.0.89"
-phf = "0.11.2"
-log = { version = "0.4.22", features = ["std", "serde"] }
-stderrlog = "0.6.0"
+actix-web.workspace = true
+anyhow.workspace = true
+base64.workspace = true
+clap.workspace = true
+ear.workspace = true
+log.workspace = true
+phf.workspace = true
+rand.workspace = true
+regorus.workspace = true
+rsa.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+stderrlog.workspace = true
+thiserror.workspace = true
+veraison-apiclient.workspace = true


### PR DESCRIPTION
So far, each project in keybroker-demo was specifying its own package dependencies, including the version pinning and features. This is undesirable as over time, it means that projects' dependencies might unnecessarily diverge. Cargo's dependency resolver is doing a good job... but hiding the mess under the carpet does not seem like a good engineering approach when there are available solutions.

Instead, let's have all the package dependencies in the top Cargo.toml, and let the individual projects refer to them. This gives us a central place where to manage the dependencies from. This may become important in the future, e.g. if we have to update some package for security reasons for example.