### PR TITLE
fix: allow installing keybroker-app again

### DIFF
--- a/rust-keybroker/Cargo.toml
+++ b/rust-keybroker/Cargo.toml
@@ -19,7 +19,7 @@ rand = "0.8.5"
 regorus = "0.2.5"
 reqwest = { version = "0.12.5", features = ["json", "rustls-tls", "blocking"] }
 rsa = "0.9.6"
-serde = "1.0.204"
+serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.128"
 serde_with = "3.9.0"
 sha2 = "0.10.8"


### PR DESCRIPTION
Following ed6ce14140df ("refactor: improve dependency management."), it's not possible to build/install keybroker-app on its own anymore:

 ```
 $ cargo install --root /tmp/install-path/ --path keybroker-app/
  ...
  error[E0433]: failed to resolve: could not find `Serialize` in `serde`
     --> keybroker-common/src/lib.rs:16:31
      |
  16  | #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
      |                               ^^^^^^^^^ could not find `Serialize` in `serde`
      |
  note: found an item that was configured out
     --> .cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.210/src/lib.rs:342:37
      |
  342 | pub use serde_derive::{Deserialize, Serialize};
      |                                     ^^^^^^^^^
      = note: the item is gated behind the `serde_derive` feature
```

Specify the 'derive' serde feature to fix this.


@Arnaud-de-Grandmaison-ARM, this is needed for packaging keybroker-app