### PR TITLE
test: add an installation CI test.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,3 +27,7 @@ jobs:
       run: cargo build --manifest-path=rust-keybroker/Cargo.toml --verbose
     - name: Run tests
       run: cargo test --manifest-path=rust-keybroker/Cargo.toml --verbose
+    - name: Install keybroker-app
+      run: cargo install --path=rust-keybroker/keybroker-app --root $RUNNER_TEMP/keybroker-demo
+    - name: Install keybroker-server
+      run: cargo install --path=rust-keybroker/keybroker-server --root $RUNNER_TEMP/keybroker-demo


### PR DESCRIPTION
For some reason, cargo install and cargo build do not do exactly the same thing.  My commit at

https://github.com/Arnaud-de-Grandmaison-ARM/keybroker-demo/commit/ed6ce14140df39b698a83471e982cc94b57e999c

broke cargo install without us noting it or CI catching it. This commit adds a test to cover this.

It should be noted that cargo install does not yet (or still does not !) play nice with workspaces, so we need to point it to each of the individual binaries that we want to install, for reference see:
 - https://github.com/rust-lang/cargo/issues/7599
 - https://github.com/rust-lang/cargo/issues/4101
 - https://github.com/rust-lang/cargo/issues/7124

We install each of the binaries into a temporary directory provided by the runner and that will be cleaned up automatically when the job finishes.