### PR TITLE
fix(keybroker-server): allow the reference values to be used multiple times.

### DIFF
--- a/rust-keybroker/keybroker-server/src/main.rs
+++ b/rust-keybroker/keybroker-server/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fs;
+use std::path::Path;
 use std::sync::Mutex;
 
 use actix_web::{http, post, rt::task, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
@@ -182,6 +184,13 @@ async fn submit_evidence(
     }
 }
 
+/// Reads the entire contents of the file at path into a string.
+/// This is basically a wrapper around the standard library's `fs::read_to_string` function so it
+/// can be used as a value parser in the command-line arguments.
+fn read_file_to_string(path: &str) -> Result<String, String> {
+    fs::read_to_string(Path::new(path)).map_err(|e| format!("failed to read {}: {}", path, e))
+}
+
 /// Structure for parsing and storing the command-line arguments
 #[derive(Clone, Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -226,7 +235,7 @@ struct Args {
     quiet: bool,
 
     /// File containing a JSON array with base64-encoded known-good reference values
-    #[arg(long, default_value = None)]
+    #[arg(long, default_value = None, value_parser = read_file_to_string, value_hint = clap::ValueHint::FilePath)]
     reference_values: Option<String>,
 }
 

--- a/rust-keybroker/keybroker-server/src/policy.rs
+++ b/rust-keybroker/keybroker-server/src/policy.rs
@@ -27,7 +27,7 @@ pub(crate) fn rego_eval(
     engine.add_policy(String::from("policy.rego"), String::from(policy))?;
 
     // Load the configured known-good reference values
-    engine.add_data(Value::from_json_file(reference_values)?)?;
+    engine.add_data(Value::from_json_str(reference_values)?)?;
 
     // Set the EAR claims-set to be appraised
     engine.set_input(Value::from_json_str(ear_claims)?);
@@ -44,12 +44,12 @@ mod tests {
     #[test]
     fn rego_eval_ear_default_policy_ok() {
         let ear_claims = include_str!("../../../testdata/ear-claims-ok.json");
-        let reference_values = stringify_testdata_path("rims-matching.json");
+        let reference_values = include_str!("../../../testdata/rims-matching.json");
 
         let results = rego_eval(
             include_str!("arm-cca.rego"),
             "data.arm_cca.allow",
-            &reference_values,
+            reference_values,
             ear_claims,
         )
         .expect("successful eval");
@@ -60,25 +60,16 @@ mod tests {
     #[test]
     fn rego_eval_default_policy_unmatched_rim() {
         let ear_claims = include_str!("../../../testdata/ear-claims-ok.json");
-        let reference_values = stringify_testdata_path("rims-not-matching.json");
+        let reference_values = include_str!("../../../testdata/rims-not-matching.json");
 
         let results = rego_eval(
             include_str!("arm-cca.rego"),
             "data.arm_cca.allow",
-            &reference_values,
+            reference_values,
             ear_claims,
         )
         .expect("successful eval");
 
         assert_eq!(results.to_string(), "false");
-    }
-
-    fn stringify_testdata_path(s: &str) -> String {
-        let mut test_data = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-
-        test_data.push("../../testdata");
-        test_data.push(s);
-
-        test_data.into_os_string().into_string().unwrap()
     }
 }


### PR DESCRIPTION
The keybroker-server is usually provisionned with known good RIM values. Our documentation shows that it can be done using the <(...) shell construct, that populates a temporary file with the output of '...' e.g.:

 $ keybroker-server --reference-values <(echo '{ "reference-values": [ "blob" ] }')

That temporary file is destroyed when keybroker-server exits (no leftover files) OR when keybroker-server opens, reads and closes it --- which is exactly what rego_eval is doing. This raise a problem as it means that rego_eval can only be called once and the reference values will disappear after this one single call, making keybroker-server only able to serve a single request in practice.

This is solved by reading the reference values file content at command line argument passing time and passing them as string (instead of a path) downto to verify_with_veraison_instance and rego_eval.

Steps to reproduce before this fix:

(terminal 1): keybroker-server -v -m --reference-values <(echo '{ "reference-values": [ "blob" ] }')
(terminal 2): keybroker-app -v -m skywalker
(terminal 2): keybroker-app -v -m skywalker

The second keybroker-app invocation will fail, and the keybroker-server will have the following error:

INFO Evidence submitted for challenge 3406997665: no attestation result was obtained. EOF while parsing a value at line 1 column 0